### PR TITLE
feat: add algolia seach

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,7 +131,14 @@ async function getConfig() {
         },
         colorMode: {
           respectPrefersColorScheme: true
-        }
+        },
+        algolia: {
+          appId: 'ENYBEQWB9S',
+          apiKey: '4375e3a9ca0bed2ccb22dc140f07d1e1',
+          indexName: 'atama',
+          contextualSearch: true,
+          searchPagePath: 'search',
+        },
       }),
 
       plugins: [


### PR DESCRIPTION
We got approved for the free Algolia docsearch so this PR adds the appropriate docusaurus config to enable the search in the header.