### PR TITLE
feat: add box shadow to images

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -49,3 +49,11 @@
 .mermaid .node.mermaidMutedElement .label span {
   color: #666 !important;
 }
+
+/* Images */
+.theme-doc-markdown.markdown img {
+  border-radius: 0.5rem;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 5px 10px, rgba(0, 0, 0, 0.2) 0px 15px 40px;
+  margin: 1rem 0;
+}
+


### PR DESCRIPTION
This PR makes the images in the docs look a little bit nicer:

![Screen Shot 2023-03-06 at 8 57 35 AM](https://user-images.githubusercontent.com/89743807/223178748-c07c3d4f-77ca-4c06-b47f-9b47e96f76f7.png)
